### PR TITLE
Feat/more quantity manager adjustments

### DIFF
--- a/src/ocelescope/src/ocelescope/ocel/managers/quantities/quantity.py
+++ b/src/ocelescope/src/ocelescope/ocel/managers/quantities/quantity.py
@@ -384,7 +384,7 @@ class QuantityManager(BaseManager):
         self,
         object_id: str,
         item_types: list[str] | None = None,
-        include_events: Literal["log", "involved", "changed"] = "changed",
+        include_events: Literal["log", "trace", "active"] = "trace",
         include_oqty: bool = True,
         pre_event: bool = False,
     ) -> pd.DataFrame:
@@ -402,8 +402,8 @@ class QuantityManager(BaseManager):
             item_types: Optional list of item type names to include. If None, all
                 item types available for the given object are included.
             include_events: Which events to include in the output:
-                "all" (all events), "involved" (events involving the object), or
-                "changed" (only events where at least one selected item type changes).
+                "log" (all events), "trace" (events involving the object), or
+                "active" (only events where at least one selected item type changes).
             include_oqty: If True, add the object's initial quantities (oqty) to the
                 cumulative development for each selected item type (i.e., return
                 absolute quantities rather than net change).
@@ -440,14 +440,14 @@ class QuantityManager(BaseManager):
             item_level_development,
             events_df,
             on=EID_COL,
-            how="left" if include_events == "changed" else "right",
+            how="left" if include_events == "active" else "right",
         )
 
         item_level_development[object_item_types] = item_level_development[
             object_item_types
         ].fillna(0)
 
-        if include_events == "changed":
+        if include_events == "active":
             item_level_development = item_level_development.loc[
                 ~item_level_development[object_item_types].eq(0).all(axis=1)
             ]

--- a/src/ocelescope/src/ocelescope/ocel/managers/quantities/quantity.py
+++ b/src/ocelescope/src/ocelescope/ocel/managers/quantities/quantity.py
@@ -384,7 +384,7 @@ class QuantityManager(BaseManager):
         self,
         object_id: str,
         item_types: list[str] | None = None,
-        include_events: Literal["all", "involved", "changed"] = "changed",
+        include_events: Literal["log", "involved", "changed"] = "changed",
         include_oqty: bool = True,
         pre_event: bool = False,
     ) -> pd.DataFrame:
@@ -431,7 +431,7 @@ class QuantityManager(BaseManager):
 
         events_df = self._ocel.events.df[[EID_COL, ACTIVITY_COL, TIMESTAMP_COL]]
 
-        if include_events != "all":
+        if include_events != "log":
             events_df = events_df.loc[
                 events_df[EID_COL].isin(self._ocel.e2o.get_events_of_object(object_id))
             ]

--- a/src/ocelescope/src/ocelescope/ocel/managers/quantities/quantity.py
+++ b/src/ocelescope/src/ocelescope/ocel/managers/quantities/quantity.py
@@ -386,6 +386,7 @@ class QuantityManager(BaseManager):
         item_types: list[str] | None = None,
         include_events: Literal["all", "involved", "changed"] = "changed",
         include_oqty: bool = True,
+        pre_event: bool = False,
     ) -> pd.DataFrame:
         """Get item-level development for an object as a per-event DataFrame.
 
@@ -452,6 +453,9 @@ class QuantityManager(BaseManager):
             ]
 
         item_level_development = item_level_development.sort_values(TIMESTAMP_COL, ascending=True)
+
+        if pre_event:
+            item_level_development = item_level_development.shift(1, fill_value=0)
 
         item_level_development[object_item_types] = item_level_development[
             object_item_types


### PR DESCRIPTION
- adresses  comments of #38 
  - https://github.com/promi4s/ocelescope/issues/38#issuecomment-4244196720
  - https://github.com/promi4s/ocelescope/issues/38#issuecomment-4250892031

This Pr:
- renames `include_events` literals of the `get_item_level_development` of the Quantity manager
   - all -> log 
   - involved -> trace
   - changed -> active
- Sets the default of `include_events` to `trace` 
- Adds a `pre_event`  parameter to the `get_object_item_level` of the Quantity manager