### PR TITLE
:bug: Fix typo in PluginBreadcrumb query

### DIFF
--- a/src/frontend/modules/plugin/src/components/PluginBreadcrumbs/PluginBreadcrumbs.tsx
+++ b/src/frontend/modules/plugin/src/components/PluginBreadcrumbs/PluginBreadcrumbs.tsx
@@ -33,7 +33,7 @@ const PluginBreadcrumbs: React.FC = () => {
         <Anchor
           component={Link}
           href={{
-            query: { ...query, pluginId: plugin?.id, methdodName: undefined },
+            query: { ...query, pluginId: plugin?.id, methodName: undefined },
           }}
         >
           {plugin?.meta.label}


### PR DESCRIPTION
- fixes the link in the PluginBreadcrumbs