### PR TITLE
:arrow_up: Fix SSE connections

### DIFF
--- a/src/backend/app/main.py
+++ b/src/backend/app/main.py
@@ -64,7 +64,7 @@ for route in routes:
     app.include_router(route)
 
 
-@app.get("/sse", response_class=EventSourceResponse)
+@app.get("/sse", response_class=EventSourceResponse, include_in_schema=False)
 async def sse_endpoint(request: Request) -> AsyncIterable[SSEMessage]:
     session_id = request.query_params.get("session_id")
     if not session_id:

--- a/src/backend/app/main.py
+++ b/src/backend/app/main.py
@@ -2,10 +2,11 @@ from __future__ import annotations
 
 import asyncio
 from contextlib import asynccontextmanager
+from typing import AsyncIterable
 
-from fastapi import FastAPI, Request
+from fastapi import FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import StreamingResponse
+from fastapi.sse import EventSourceResponse
 
 from app.internal.config import config
 from app.internal.docs import init_custom_docs
@@ -18,7 +19,7 @@ from app.internal.utils import (
 )
 from app.middleware import session_access_middleware
 from app.routes import routes
-from app.sse_manager import sse_manager
+from app.sse_manager import SSEMessage, sse_manager
 from version import __version__
 
 
@@ -63,35 +64,19 @@ for route in routes:
     app.include_router(route)
 
 
-@app.get("/sse")
-async def sse_endpoint(request: Request):
+@app.get("/sse", response_class=EventSourceResponse)
+async def sse_endpoint(request: Request) -> AsyncIterable[SSEMessage]:
     session_id = request.query_params.get("session_id")
-
     if not session_id:
-        return StreamingResponse(
-            iter(["data: Missing session_id\n\n"]), media_type="text/event-stream"
-        )
+        raise HTTPException(status_code=400, detail="Missing session_id")
 
     queue = await sse_manager.connect(session_id)
-    print(f"✅ SSE connected for session: {session_id}")
 
-    async def event_stream():
-        try:
-            while True:
-                if await request.is_disconnected():
-                    print(f"❌ SSE disconnected for session: {session_id}")
-                    sse_manager.disconnect(session_id)
-                    break
-
-                try:
-                    msg = await asyncio.wait_for(queue.get(), timeout=25)
-                    yield f"data: {msg}\n\n"
-                except asyncio.TimeoutError:
-                    yield ": keep-alive\n\n"
-        except asyncio.CancelledError:
-            sse_manager.disconnect(session_id)
-
-    return StreamingResponse(event_stream(), media_type="text/event-stream")
+    try:
+        while not await request.is_disconnected():
+            yield await queue.get()
+    finally:
+        sse_manager.disconnect(session_id)
 
 
 init_custom_docs(app)

--- a/src/backend/app/sse_manager.py
+++ b/src/backend/app/sse_manager.py
@@ -39,12 +39,8 @@ class InvalidationRequest(BaseModel):
     routes: list[Literal["resources", "ocels", "tasks", "plugins"]]
 
 
-class InvalidSession(BaseModel):
-    type: Literal["invalid-session"] = "invalid-session"
-
-
 SSEMessage = Annotated[
-    Union[SystemNotification, InvalidationRequest, InvalidSession],
+    Union[SystemNotification, InvalidationRequest],
     Field(discriminator="type"),
 ]
 

--- a/src/backend/app/sse_manager.py
+++ b/src/backend/app/sse_manager.py
@@ -39,21 +39,26 @@ class InvalidationRequest(BaseModel):
     routes: list[Literal["resources", "ocels", "tasks", "plugins"]]
 
 
+class InvalidSession(BaseModel):
+    type: Literal["invalid-session"] = "invalid-session"
+
+
 SSEMessage = Annotated[
-    Union[SystemNotification, InvalidationRequest], Field(discriminator="type")
+    Union[SystemNotification, InvalidationRequest, InvalidSession],
+    Field(discriminator="type"),
 ]
 
 
 class SSEManager:
     def __init__(self):
-        self.connections: dict[str, asyncio.Queue[str]] = {}
+        self.connections: dict[str, asyncio.Queue[SSEMessage]] = {}
         self.loop: asyncio.AbstractEventLoop | None = None
 
     def set_loop(self, loop: asyncio.AbstractEventLoop):
         """Store event loop reference for thread-safe sends."""
         self.loop = loop
 
-    async def connect(self, session_id: str) -> asyncio.Queue[str]:
+    async def connect(self, session_id: str) -> asyncio.Queue[SSEMessage]:
         """Create a message queue for the connected session."""
         queue = asyncio.Queue()
         self.connections[session_id] = queue
@@ -63,14 +68,13 @@ class SSEManager:
         """Remove session connection."""
         self.connections.pop(session_id, None)
 
-    # Use full SSE api and name events
     async def send(self, session_id: str, message: SSEMessage):
         """Send JSON message to one client (async)."""
         queue = self.connections.get(session_id)
         if queue:
-            await queue.put(message.model_dump_json())
+            await queue.put(message)
 
-    async def broadcast(self, message: str):
+    async def broadcast(self, message: SSEMessage):
         """Send plain text to all clients (async)."""
         for q in self.connections.values():
             await q.put(message)

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -15,9 +15,8 @@ dependencies = [
   "cachetools>=6.1.0",
   "pydantic>=2.11.7",
   "pydantic-settings>=2.2.1,<3",
-  "fastapi[standard]>=0.112.2",
+  "fastapi[standard]>=0.136.0",
   "uvicorn>=0.28.0,<0.29",
-  "python-multipart>=0.0.9,<0.0.10",
   "ocelescope",
   "orjson>=3.11.3",
 ]

--- a/src/frontend/packages/api/base/openapi.json
+++ b/src/frontend/packages/api/base/openapi.json
@@ -3030,8 +3030,51 @@
           "200": {
             "description": "Successful Response",
             "content": {
-              "application/json": {
-                "schema": {}
+              "text/event-stream": {
+                "itemSchema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "string",
+                      "contentMediaType": "application/json",
+                      "contentSchema": {
+                        "oneOf": [
+                          {
+                            "$ref": "#/components/schemas/SystemNotification"
+                          },
+                          {
+                            "$ref": "#/components/schemas/InvalidationRequest"
+                          },
+                          {
+                            "$ref": "#/components/schemas/InvalidSession"
+                          }
+                        ],
+                        "discriminator": {
+                          "propertyName": "type",
+                          "mapping": {
+                            "notification": "#/components/schemas/SystemNotification",
+                            "invalidation": "#/components/schemas/InvalidationRequest",
+                            "invalid-session": "#/components/schemas/InvalidSession"
+                          }
+                        },
+                        "title": "Streamitem Sse Endpoint Sse Get"
+                      }
+                    },
+                    "event": {
+                      "type": "string"
+                    },
+                    "id": {
+                      "type": "string"
+                    },
+                    "retry": {
+                      "type": "integer",
+                      "minimum": 0
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ]
+                }
               }
             }
           }
@@ -4126,6 +4169,46 @@
         "type": "object",
         "title": "HTTPValidationError"
       },
+      "InvalidSession": {
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "invalid-session",
+            "title": "Type",
+            "default": "invalid-session"
+          }
+        },
+        "type": "object",
+        "title": "InvalidSession"
+      },
+      "InvalidationRequest": {
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "invalidation",
+            "title": "Type",
+            "default": "invalidation"
+          },
+          "routes": {
+            "items": {
+              "type": "string",
+              "enum": [
+                "resources",
+                "ocels",
+                "tasks",
+                "plugins"
+              ]
+            },
+            "type": "array",
+            "title": "Routes"
+          }
+        },
+        "type": "object",
+        "required": [
+          "routes"
+        ],
+        "title": "InvalidationRequest"
+      },
       "O2OCountFilter": {
         "properties": {
           "source": {
@@ -4536,6 +4619,25 @@
         ],
         "title": "OcelEntity"
       },
+      "OcelLink": {
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "ocel",
+            "title": "Type",
+            "default": "ocel"
+          },
+          "ocel_id": {
+            "type": "string",
+            "title": "Ocel Id"
+          }
+        },
+        "type": "object",
+        "required": [
+          "ocel_id"
+        ],
+        "title": "OcelLink"
+      },
       "OcelMetadata": {
         "properties": {
           "id": {
@@ -4685,6 +4787,35 @@
           "methods"
         ],
         "title": "PluginApi"
+      },
+      "PluginLink": {
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "plugin",
+            "title": "Type",
+            "default": "plugin"
+          },
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "method": {
+            "type": "string",
+            "title": "Method"
+          },
+          "task_id": {
+            "type": "string",
+            "title": "Task Id"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "method",
+          "task_id"
+        ],
+        "title": "PluginLink"
       },
       "PluginMeta": {
         "properties": {
@@ -5078,6 +5209,25 @@
         ],
         "title": "ResourceInfo"
       },
+      "ResourceLink": {
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "resource",
+            "title": "Type",
+            "default": "resource"
+          },
+          "resource_id": {
+            "type": "string",
+            "title": "Resource Id"
+          }
+        },
+        "type": "object",
+        "required": [
+          "resource_id"
+        ],
+        "title": "ResourceLink"
+      },
       "ResourceResult": {
         "properties": {
           "type": {
@@ -5131,6 +5281,69 @@
           "svg"
         ],
         "title": "SVGVis"
+      },
+      "SystemNotification": {
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "notification",
+            "title": "Type",
+            "default": "notification"
+          },
+          "title": {
+            "type": "string",
+            "title": "Title"
+          },
+          "message": {
+            "type": "string",
+            "title": "Message"
+          },
+          "notification_type": {
+            "type": "string",
+            "enum": [
+              "warning",
+              "info",
+              "error"
+            ],
+            "title": "Notification Type"
+          },
+          "link": {
+            "anyOf": [
+              {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/OcelLink"
+                  },
+                  {
+                    "$ref": "#/components/schemas/PluginLink"
+                  },
+                  {
+                    "$ref": "#/components/schemas/ResourceLink"
+                  }
+                ],
+                "discriminator": {
+                  "propertyName": "type",
+                  "mapping": {
+                    "ocel": "#/components/schemas/OcelLink",
+                    "plugin": "#/components/schemas/PluginLink",
+                    "resource": "#/components/schemas/ResourceLink"
+                  }
+                }
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Link"
+          }
+        },
+        "type": "object",
+        "required": [
+          "title",
+          "message",
+          "notification_type"
+        ],
+        "title": "SystemNotification"
       },
       "SystemTaskSummary": {
         "properties": {

--- a/src/frontend/packages/api/base/openapi.json
+++ b/src/frontend/packages/api/base/openapi.json
@@ -3021,65 +3021,6 @@
           }
         }
       }
-    },
-    "/sse": {
-      "get": {
-        "summary": "Sse Endpoint",
-        "operationId": "sse_endpoint_sse_get",
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "text/event-stream": {
-                "itemSchema": {
-                  "type": "object",
-                  "properties": {
-                    "data": {
-                      "type": "string",
-                      "contentMediaType": "application/json",
-                      "contentSchema": {
-                        "oneOf": [
-                          {
-                            "$ref": "#/components/schemas/SystemNotification"
-                          },
-                          {
-                            "$ref": "#/components/schemas/InvalidationRequest"
-                          },
-                          {
-                            "$ref": "#/components/schemas/InvalidSession"
-                          }
-                        ],
-                        "discriminator": {
-                          "propertyName": "type",
-                          "mapping": {
-                            "notification": "#/components/schemas/SystemNotification",
-                            "invalidation": "#/components/schemas/InvalidationRequest",
-                            "invalid-session": "#/components/schemas/InvalidSession"
-                          }
-                        },
-                        "title": "Streamitem Sse Endpoint Sse Get"
-                      }
-                    },
-                    "event": {
-                      "type": "string"
-                    },
-                    "id": {
-                      "type": "string"
-                    },
-                    "retry": {
-                      "type": "integer",
-                      "minimum": 0
-                    }
-                  },
-                  "required": [
-                    "data"
-                  ]
-                }
-              }
-            }
-          }
-        }
-      }
     }
   },
   "components": {
@@ -4169,46 +4110,6 @@
         "type": "object",
         "title": "HTTPValidationError"
       },
-      "InvalidSession": {
-        "properties": {
-          "type": {
-            "type": "string",
-            "const": "invalid-session",
-            "title": "Type",
-            "default": "invalid-session"
-          }
-        },
-        "type": "object",
-        "title": "InvalidSession"
-      },
-      "InvalidationRequest": {
-        "properties": {
-          "type": {
-            "type": "string",
-            "const": "invalidation",
-            "title": "Type",
-            "default": "invalidation"
-          },
-          "routes": {
-            "items": {
-              "type": "string",
-              "enum": [
-                "resources",
-                "ocels",
-                "tasks",
-                "plugins"
-              ]
-            },
-            "type": "array",
-            "title": "Routes"
-          }
-        },
-        "type": "object",
-        "required": [
-          "routes"
-        ],
-        "title": "InvalidationRequest"
-      },
       "O2OCountFilter": {
         "properties": {
           "source": {
@@ -4619,25 +4520,6 @@
         ],
         "title": "OcelEntity"
       },
-      "OcelLink": {
-        "properties": {
-          "type": {
-            "type": "string",
-            "const": "ocel",
-            "title": "Type",
-            "default": "ocel"
-          },
-          "ocel_id": {
-            "type": "string",
-            "title": "Ocel Id"
-          }
-        },
-        "type": "object",
-        "required": [
-          "ocel_id"
-        ],
-        "title": "OcelLink"
-      },
       "OcelMetadata": {
         "properties": {
           "id": {
@@ -4787,35 +4669,6 @@
           "methods"
         ],
         "title": "PluginApi"
-      },
-      "PluginLink": {
-        "properties": {
-          "type": {
-            "type": "string",
-            "const": "plugin",
-            "title": "Type",
-            "default": "plugin"
-          },
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
-          "method": {
-            "type": "string",
-            "title": "Method"
-          },
-          "task_id": {
-            "type": "string",
-            "title": "Task Id"
-          }
-        },
-        "type": "object",
-        "required": [
-          "id",
-          "method",
-          "task_id"
-        ],
-        "title": "PluginLink"
       },
       "PluginMeta": {
         "properties": {
@@ -5209,25 +5062,6 @@
         ],
         "title": "ResourceInfo"
       },
-      "ResourceLink": {
-        "properties": {
-          "type": {
-            "type": "string",
-            "const": "resource",
-            "title": "Type",
-            "default": "resource"
-          },
-          "resource_id": {
-            "type": "string",
-            "title": "Resource Id"
-          }
-        },
-        "type": "object",
-        "required": [
-          "resource_id"
-        ],
-        "title": "ResourceLink"
-      },
       "ResourceResult": {
         "properties": {
           "type": {
@@ -5281,69 +5115,6 @@
           "svg"
         ],
         "title": "SVGVis"
-      },
-      "SystemNotification": {
-        "properties": {
-          "type": {
-            "type": "string",
-            "const": "notification",
-            "title": "Type",
-            "default": "notification"
-          },
-          "title": {
-            "type": "string",
-            "title": "Title"
-          },
-          "message": {
-            "type": "string",
-            "title": "Message"
-          },
-          "notification_type": {
-            "type": "string",
-            "enum": [
-              "warning",
-              "info",
-              "error"
-            ],
-            "title": "Notification Type"
-          },
-          "link": {
-            "anyOf": [
-              {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/OcelLink"
-                  },
-                  {
-                    "$ref": "#/components/schemas/PluginLink"
-                  },
-                  {
-                    "$ref": "#/components/schemas/ResourceLink"
-                  }
-                ],
-                "discriminator": {
-                  "propertyName": "type",
-                  "mapping": {
-                    "ocel": "#/components/schemas/OcelLink",
-                    "plugin": "#/components/schemas/PluginLink",
-                    "resource": "#/components/schemas/ResourceLink"
-                  }
-                }
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Link"
-          }
-        },
-        "type": "object",
-        "required": [
-          "title",
-          "message",
-          "notification_type"
-        ],
-        "title": "SystemNotification"
       },
       "SystemTaskSummary": {
         "properties": {

--- a/src/frontend/packages/api/base/openapi.json
+++ b/src/frontend/packages/api/base/openapi.json
@@ -3193,7 +3193,7 @@
           "files": {
             "items": {
               "type": "string",
-              "format": "binary"
+              "contentMediaType": "application/octet-stream"
             },
             "type": "array",
             "title": "Files"
@@ -3209,7 +3209,7 @@
         "properties": {
           "file": {
             "type": "string",
-            "format": "binary",
+            "contentMediaType": "application/octet-stream",
             "title": "File"
           }
         },
@@ -3223,7 +3223,7 @@
         "properties": {
           "file": {
             "type": "string",
-            "format": "binary",
+            "contentMediaType": "application/octet-stream",
             "title": "File"
           }
         },
@@ -4976,6 +4976,21 @@
         ],
         "title": "RelationCountSummary"
       },
+      "Resource": {
+        "properties": {
+          "_ocelescope_resource_type": {
+            "type": "string",
+            "title": "Ocelescope Resource Type",
+            "readOnly": true
+          }
+        },
+        "type": "object",
+        "required": [
+          "_ocelescope_resource_type"
+        ],
+        "title": "Resource",
+        "description": "Abstract base class for resources.\n\nAttributes:\n    label: Optional human-readable label for this resource class.\n    description: Optional human-readable description for this resource class."
+      },
       "ResourceAnnotation": {
         "properties": {
           "label": {
@@ -5365,6 +5380,13 @@
           "type": {
             "type": "string",
             "title": "Error Type"
+          },
+          "input": {
+            "title": "Input"
+          },
+          "ctx": {
+            "type": "object",
+            "title": "Context"
           }
         },
         "type": "object",

--- a/src/frontend/packages/core/src/lib/sse.ts
+++ b/src/frontend/packages/core/src/lib/sse.ts
@@ -12,6 +12,7 @@ const ResourceLink = z.object({
 
 const PluginLink = z.object({
   type: z.literal("plugin"),
+  id: z.string(),
   method: z.string(),
   task_id: z.string(),
 });
@@ -27,7 +28,7 @@ const SystemNotification = z.object({
   title: z.string(),
   message: z.string(),
   notification_type: z.enum(["warning", "info", "error"]),
-  link: SystemLink,
+  link: z.optional(SystemLink),
 });
 
 const InvalidationRequest = z.object({

--- a/uv.lock
+++ b/uv.lock
@@ -562,24 +562,29 @@ wheels = [
 
 [[package]]
 name = "fastapi"
-version = "0.115.6"
+version = "0.136.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "annotated-doc" },
     { name = "pydantic" },
     { name = "starlette" },
     { name = "typing-extensions" },
+    { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/93/72/d83b98cd106541e8f5e5bfab8ef2974ab45a62e8a6c5b5e6940f26d2ed4b/fastapi-0.115.6.tar.gz", hash = "sha256:9ec46f7addc14ea472958a96aae5b5de65f39721a46aaf5705c480d9a8b76654", size = 301336, upload-time = "2024-12-03T22:46:01.629Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/d9/e66315807e41e69e7f6a1b42a162dada2f249c5f06ad3f1a95f84ab336ef/fastapi-0.136.0.tar.gz", hash = "sha256:cf08e067cc66e106e102d9ba659463abfac245200752f8a5b7b1e813de4ff73e", size = 396607, upload-time = "2026-04-16T11:47:13.623Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/52/b3/7e4df40e585df024fac2f80d1a2d579c854ac37109675db2b0cc22c0bb9e/fastapi-0.115.6-py3-none-any.whl", hash = "sha256:e9240b29e36fa8f4bb7290316988e90c381e5092e0cbe84e7818cc3713bcf305", size = 94843, upload-time = "2024-12-03T22:45:59.368Z" },
+    { url = "https://files.pythonhosted.org/packages/26/a3/0bd5f0cdb0bbc92650e8dc457e9250358411ee5d1b65e42b6632387daf81/fastapi-0.136.0-py3-none-any.whl", hash = "sha256:8793d44ec7378e2be07f8a013cf7f7aa47d6327d0dfe9804862688ec4541a6b4", size = 117556, upload-time = "2026-04-16T11:47:11.922Z" },
 ]
 
 [package.optional-dependencies]
 standard = [
     { name = "email-validator" },
     { name = "fastapi-cli", extra = ["standard"] },
+    { name = "fastar" },
     { name = "httpx" },
     { name = "jinja2" },
+    { name = "pydantic-extra-types" },
+    { name = "pydantic-settings" },
     { name = "python-multipart" },
     { name = "uvicorn", extra = ["standard"] },
 ]
@@ -1909,7 +1914,6 @@ dependencies = [
     { name = "pm4py" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
-    { name = "python-multipart" },
     { name = "uvicorn" },
 ]
 
@@ -1926,7 +1930,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "cachetools", specifier = ">=6.1.0" },
-    { name = "fastapi", extras = ["standard"], specifier = ">=0.112.2" },
+    { name = "fastapi", extras = ["standard"], specifier = ">=0.136.0" },
     { name = "numpy", specifier = ">=2.3.2" },
     { name = "ocelescope", editable = "src/ocelescope" },
     { name = "orjson", specifier = ">=3.11.3" },
@@ -1935,7 +1939,6 @@ requires-dist = [
     { name = "pm4py", specifier = "~=2.7.22" },
     { name = "pydantic", specifier = ">=2.11.7" },
     { name = "pydantic-settings", specifier = ">=2.2.1,<3" },
-    { name = "python-multipart", specifier = ">=0.0.9,<0.0.10" },
     { name = "uvicorn", specifier = ">=0.28.0,<0.29" },
 ]
 
@@ -2491,6 +2494,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pydantic-extra-types"
+version = "2.11.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/71/dba38ee2651f84f7842206adbd2233d8bbdb59fb85e9fa14232486a8c471/pydantic_extra_types-2.11.1.tar.gz", hash = "sha256:46792d2307383859e923d8fcefa82108b1a141f8a9c0198982b3832ab5ef1049", size = 172002, upload-time = "2026-03-16T08:08:03.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/17/c1/3226e6d7f5a4f736f38ac11a6fbb262d701889802595cdb0f53a885ac2e0/pydantic_extra_types-2.11.1-py3-none-any.whl", hash = "sha256:1722ea2bddae5628ace25f2aa685b69978ef533123e5638cfbddb999e0100ec1", size = 79526, upload-time = "2026-03-16T08:08:02.533Z" },
+]
+
+[[package]]
 name = "pydantic-settings"
 version = "2.13.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2580,11 +2596,11 @@ wheels = [
 
 [[package]]
 name = "python-multipart"
-version = "0.0.9"
+version = "0.0.26"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5c/0f/9c55ac6c84c0336e22a26fa84ca6c51d58d7ac3a2d78b0dfa8748826c883/python_multipart-0.0.9.tar.gz", hash = "sha256:03f54688c663f1b7977105f021043b0793151e4cb1c1a9d4a11fc13d622c4026", size = 31516, upload-time = "2024-02-10T13:32:04.684Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/88/71/b145a380824a960ebd60e1014256dbb7d2253f2316ff2d73dfd8928ec2c3/python_multipart-0.0.26.tar.gz", hash = "sha256:08fadc45918cd615e26846437f50c5d6d23304da32c341f289a617127b081f17", size = 43501, upload-time = "2026-04-10T14:09:59.473Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3d/47/444768600d9e0ebc82f8e347775d24aef8f6348cf00e9fa0e81910814e6d/python_multipart-0.0.9-py3-none-any.whl", hash = "sha256:97ca7b8ea7b05f977dc3849c3ba99d51689822fab725c3703af7c866a0c2b215", size = 22299, upload-time = "2024-02-10T13:32:02.969Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/22/f1925cdda983ab66fc8ec6ec8014b959262747e58bdca26a4e3d1da29d56/python_multipart-0.0.26-py3-none-any.whl", hash = "sha256:c0b169f8c4484c13b0dcf2ef0ec3a4adb255c4b7d18d8e420477d2b1dd03f185", size = 28847, upload-time = "2026-04-10T14:09:58.131Z" },
 ]
 
 [[package]]
@@ -3212,14 +3228,14 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "0.41.3"
+version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1a/4c/9b5764bd22eec91c4039ef4c55334e9187085da2d8a2df7bd570869aae18/starlette-0.41.3.tar.gz", hash = "sha256:0e4ab3d16522a255be6b28260b938eae2482f98ce5cc934cb08dce8dc3ba5835", size = 2574159, upload-time = "2024-11-18T19:45:04.283Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/96/00/2b325970b3060c7cecebab6d295afe763365822b1306a12eeab198f74323/starlette-0.41.3-py3-none-any.whl", hash = "sha256:44cedb2b7c77a9de33a8b74b2b90e9f50d11fcf25d8270ea525ad71a25374ff7", size = 73225, upload-time = "2024-11-18T19:45:02.027Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- part of #57 

This Pr fixes the unreliable SSE connection used to invalidate tanstack-queries. 
They disconnect frequently but luckily just sitting and ignoring this issue was the right decision as [SSE is now implemented as a standard in FastAPI](https://fastapi.tiangolo.com/tutorial/server-sent-events/)

## TODO
- [x] Upgrade Fastapi
- [x] Use FastApis implementation of SSE
- [x] Properly type SSE responses