### PR TITLE
:sparkles: Add logout button back to Navbar

### DIFF
--- a/src/frontend/packages/core/src/components/AppShell/AppShell.tsx
+++ b/src/frontend/packages/core/src/components/AppShell/AppShell.tsx
@@ -11,7 +11,7 @@ import { useState } from "react";
 import type { OcelescopeConfig } from "../../lib/config";
 import { CurrentOcelSelect } from "../OcelSelect/OcelSelect";
 import { UploadModal } from "../UploadModal/UploadModal";
-import NavBar from "./components/Header";
+import NavBar from "./components/NavBar";
 
 export const AppShell: React.FC<{
   config: OcelescopeConfig;

--- a/src/frontend/packages/core/src/components/AppShell/components/NavBar.tsx
+++ b/src/frontend/packages/core/src/components/AppShell/components/NavBar.tsx
@@ -1,12 +1,74 @@
-import { AppShell, Divider, NavLink, Stack } from "@mantine/core";
-import { useGetOcels } from "@ocelescope/api-base";
-import { HomeIcon, PackageIcon } from "lucide-react";
+import {
+  AppShell,
+  Button,
+  Divider,
+  Group,
+  Modal,
+  NavLink,
+  Stack,
+  Text,
+  UnstyledButton,
+} from "@mantine/core";
+import { useGetOcels, useLogout } from "@ocelescope/api-base";
+import { HomeIcon, LogOutIcon, PackageIcon } from "lucide-react";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import useModulePath from "../../../hooks/useModulePath";
 import type { OcelescopeConfig } from "../../../lib/config";
 import { getModuleRoute } from "../../../lib/getModuleRoute";
 import classes from "../AppShell.module.css";
+import { useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+
+const LogoutButton: React.FC = () => {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const queryClient = useQueryClient();
+  const { push } = useRouter();
+  const { mutate: logout } = useLogout({
+    mutation: {
+      onSuccess: () => {
+        queryClient.clear();
+        setIsModalOpen(false);
+        push("/");
+      },
+    },
+  });
+
+  return (
+    <>
+      <Modal
+        opened={isModalOpen}
+        onClose={() => setIsModalOpen(false)}
+        title="Are you sure?"
+      >
+        <Text>
+          If you leave now, all your data and progress will be{" "}
+          <strong>deleted permanently</strong>. This action cannot be undone.
+        </Text>
+
+        <Button
+          color="red"
+          mt="md"
+          onClick={() => {
+            logout();
+          }}
+          fullWidth
+        >
+          Accept
+        </Button>
+      </Modal>
+      <UnstyledButton
+        className={classes.button ?? ""}
+        onClick={() => setIsModalOpen(true)}
+      >
+        <Group justify={"space-between"} w={"100%"}>
+          <Text style={{ lineHeight: 1 }}>Logout</Text>
+          <LogOutIcon className={classes.buttonIcon} />
+        </Group>
+      </UnstyledButton>
+    </>
+  );
+};
 
 const NavBar: React.FC<{ config: OcelescopeConfig }> = ({ config }) => {
   const { modules = [] } = config;
@@ -77,6 +139,7 @@ const NavBar: React.FC<{ config: OcelescopeConfig }> = ({ config }) => {
           })}
         </Stack>
         <Divider />
+        <LogoutButton />
       </Stack>
     </AppShell.Navbar>
   );

--- a/src/frontend/packages/core/tsconfig.json
+++ b/src/frontend/packages/core/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@tsconfig/strictest/tsconfig.json",
   "compilerOptions": {
+    "noPropertyAccessFromIndexSignature": false,
     "target": "esnext",
     "jsx": "react-jsx",
     "lib": ["es2023", "DOM"],


### PR DESCRIPTION
- part of #57 

The logout button was removed and forgotten to re-add after the big frontend refactoring. 
This PR re-adds the logout button back to the navbar