### PR TITLE
:sparkles: XES export in tool

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,9 +33,6 @@ catalogs:
     '@mantine/dates':
       specifier: ^8.3.15
       version: 8.3.16
-    '@mantine/dropzone':
-      specifier: ^8.3.14
-      version: 8.3.16
     '@mantine/hooks':
       specifier: ^8.3.14
       version: 8.3.16
@@ -81,6 +78,9 @@ catalogs:
     '@types/node':
       specifier: ^25.0.3
       version: 25.3.3
+    '@types/qs':
+      specifier: ^6.15.1
+      version: 6.15.1
     '@types/react':
       specifier: ^19.2.7
       version: 19.2.14
@@ -102,12 +102,6 @@ catalogs:
     bumpp:
       specifier: ^10.3.2
       version: 10.4.1
-    clsx:
-      specifier: ^2.1.1
-      version: 2.1.1
-    content-disposition-attachment:
-      specifier: ^0.3.1
-      version: 0.3.1
     cytoscape:
       specifier: ^3.33.1
       version: 3.33.1
@@ -150,6 +144,9 @@ catalogs:
     orval:
       specifier: ^8.5.2
       version: 8.5.2
+    qs:
+      specifier: ^6.15.1
+      version: 6.15.1
     react:
       specifier: ^19.2.0
       version: 19.2.3
@@ -652,6 +649,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 25.3.3
+      '@types/qs':
+        specifier: 'catalog:'
+        version: 6.15.1
       '@types/react':
         specifier: 'catalog:'
         version: 19.2.14
@@ -661,6 +661,9 @@ importers:
       bumpp:
         specifier: 'catalog:'
         version: 10.4.1
+      qs:
+        specifier: 'catalog:'
+        version: 6.15.1
       tsdown:
         specifier: 'catalog:'
         version: 0.21.4(@tsdown/css@0.21.4)(typescript@5.9.3)
@@ -2121,6 +2124,9 @@ packages:
   '@types/plotly.js@3.0.10':
     resolution: {integrity: sha512-q+MgO4aajC2HrO7FllTYWzrpdfbTjboSMfjkz/aXKjg1v7HNo1zMEFfAW7quKfk6SL+bH74A5ThBEps/7hZxOA==}
 
+  '@types/qs@6.15.1':
+    resolution: {integrity: sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw==}
+
   '@types/react-cytoscapejs@1.2.6':
     resolution: {integrity: sha512-Nivfky/kuzT4BtIXpv5hV79Kfn+DUiBiftQeCvFCLUhqxz2ADgUxMYdHtxAUpfHiYZYuU9CWM8tGBTaybTH5+A==}
 
@@ -2360,6 +2366,10 @@ packages:
 
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
     engines: {node: '>= 0.4'}
 
   caniuse-lite@1.0.30001776:
@@ -3580,6 +3590,10 @@ packages:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
 
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
+
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
@@ -3755,6 +3769,10 @@ packages:
   punycode.js@2.3.1:
     resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
     engines: {node: '>=6'}
+
+  qs@6.15.1:
+    resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
+    engines: {node: '>=0.6'}
 
   quansync@1.0.0:
     resolution: {integrity: sha512-5xZacEEufv3HSTPQuchrvV6soaiACMFnq1H8wkVioctoH3TRha9Sz66lOxRwPK/qZj7HPiSveih9yAyh98gvqA==}
@@ -4035,6 +4053,22 @@ packages:
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
+
+  side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.0:
+    resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
+    engines: {node: '>= 0.4'}
 
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
@@ -5807,6 +5841,8 @@ snapshots:
 
   '@types/plotly.js@3.0.10': {}
 
+  '@types/qs@6.15.1': {}
+
   '@types/react-cytoscapejs@1.2.6':
     dependencies:
       '@types/react': 19.2.14
@@ -6051,6 +6087,11 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
       function-bind: 1.1.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
 
   caniuse-lite@1.0.30001776: {}
 
@@ -7264,6 +7305,8 @@ snapshots:
 
   object-assign@4.1.1: {}
 
+  object-inspect@1.13.4: {}
+
   obug@2.1.1: {}
 
   ohash@2.0.11: {}
@@ -7496,6 +7539,10 @@ snapshots:
   proxy-from-env@2.1.0: {}
 
   punycode.js@2.3.1: {}
+
+  qs@6.15.1:
+    dependencies:
+      side-channel: 1.1.0
 
   quansync@1.0.0: {}
 
@@ -7878,6 +7925,34 @@ snapshots:
       shebang-regex: 3.0.0
 
   shebang-regex@3.0.0: {}
+
+  side-channel-list@1.0.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
+  side-channel@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
 
   signal-exit@4.1.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -30,6 +30,7 @@ catalog:
   '@types/file-saver': ^2.0.7
   '@types/lodash': ^4.17.23
   '@types/node': ^25.0.3
+  '@types/qs': ^6.15.1
   '@types/react': ^19.2.7
   '@types/react-cytoscapejs': ^1.2.6
   '@types/react-dom': ^19.2.3
@@ -53,6 +54,7 @@ catalog:
   mantine-datatable: ^8.3.13
   next: ^16.1.6
   orval: ^8.5.2
+  qs: ^6.15.1
   react: ^19.2.0
   react-cytoscapejs: ^2.0.0
   react-dom: ^19.2.0

--- a/src/backend/app/routes/ocels.py
+++ b/src/backend/app/routes/ocels.py
@@ -384,4 +384,23 @@ def download_ocel(
     return file_response
 
 
+@ocels_router.get(
+    "/{ocel_id}/download/xes", summary="Download OCEL including app state"
+)
+def download_flat_log(
+    ocel: ApiOcel, object_type_name: Literal[".xes"]
+) -> TempFileResponse:
+    name = ocel.meta.extra["name"]
+    tmp_file_prefix = datetime.now().strftime("%Y%m%d-%H%M%S") + "-" + name
+
+    file_response = TempFileResponse(
+        prefix=tmp_file_prefix,
+        suffix=".xes",
+    )
+
+    ocel.write_xes(object_type_name, Path(file_response.tmp_path))
+
+    return file_response
+
+
 # endregion

--- a/src/backend/app/routes/ocels.py
+++ b/src/backend/app/routes/ocels.py
@@ -367,7 +367,11 @@ def get_quantity_info(
 
 # endregion
 # region Export
-@ocels_router.get("/{ocel_id}/download", summary="Download OCEL including app state")
+@ocels_router.get(
+    "/{ocel_id}/download",
+    summary="Download OCEL",
+    operation_id="downloadOCEL",
+)
 def download_ocel(
     ocel: ApiOcel,
     ext: OCELFileExtensions = ".json",
@@ -385,7 +389,9 @@ def download_ocel(
 
 
 @ocels_router.get(
-    "/{ocel_id}/download/xes", summary="Download OCEL including app state"
+    "/{ocel_id}/download/xes",
+    summary="Download OCEL as a xes",
+    operation_id="downloadFlatLog",
 )
 def download_flat_log(
     ocel: ApiOcel, object_type_name: Literal[".xes"]

--- a/src/backend/app/routes/ocels.py
+++ b/src/backend/app/routes/ocels.py
@@ -393,9 +393,7 @@ def download_ocel(
     summary="Download OCEL as a xes",
     operation_id="downloadFlatLog",
 )
-def download_flat_log(
-    ocel: ApiOcel, object_type_name: Literal[".xes"]
-) -> TempFileResponse:
+def download_flat_log(ocel: ApiOcel, object_type_name: str) -> TempFileResponse:
     name = ocel.meta.extra["name"]
     tmp_file_prefix = datetime.now().strftime("%Y%m%d-%H%M%S") + "-" + name
 

--- a/src/frontend/packages/api/base/openapi.json
+++ b/src/frontend/packages/api/base/openapi.json
@@ -2181,7 +2181,6 @@
             "in": "query",
             "required": true,
             "schema": {
-              "const": ".xes",
               "type": "string",
               "title": "Object Type Name"
             }

--- a/src/frontend/packages/api/base/openapi.json
+++ b/src/frontend/packages/api/base/openapi.json
@@ -2152,6 +2152,84 @@
         }
       }
     },
+    "/ocels/{ocel_id}/download/xes": {
+      "get": {
+        "tags": [
+          "ocels"
+        ],
+        "summary": "Download OCEL including app state",
+        "operationId": "download_flat_log_ocels__ocel_id__download_xes_get",
+        "parameters": [
+          {
+            "name": "ocel_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Ocel Id"
+            }
+          },
+          {
+            "name": "object_type_name",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "const": ".xes",
+              "type": "string",
+              "title": "Object Type Name"
+            }
+          },
+          {
+            "name": "ocel_version",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "enum": [
+                    "original",
+                    "filtered"
+                  ],
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": "filtered",
+              "title": "Ocel Version"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/tasks/system": {
       "get": {
         "tags": [

--- a/src/frontend/packages/api/base/openapi.json
+++ b/src/frontend/packages/api/base/openapi.json
@@ -2074,8 +2074,8 @@
         "tags": [
           "ocels"
         ],
-        "summary": "Download OCEL including app state",
-        "operationId": "download_ocel_ocels__ocel_id__download_get",
+        "summary": "Download OCEL",
+        "operationId": "downloadOCEL",
         "parameters": [
           {
             "name": "ocel_id",
@@ -2157,8 +2157,8 @@
         "tags": [
           "ocels"
         ],
-        "summary": "Download OCEL including app state",
-        "operationId": "download_flat_log_ocels__ocel_id__download_xes_get",
+        "summary": "Download OCEL as a xes",
+        "operationId": "downloadFlatLog",
         "parameters": [
           {
             "name": "ocel_id",

--- a/src/frontend/packages/core/package.json
+++ b/src/frontend/packages/core/package.json
@@ -49,6 +49,7 @@
     "lucide-react": "catalog:",
     "mantine-datatable": "catalog:",
     "next": "catalog:",
+    "qs": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:",
     "zod": "catalog:",
@@ -56,14 +57,16 @@
   },
   "devDependencies": {
     "@mantine/notifications": "catalog:",
+    "@tsdown/css": "catalog:",
     "@types/css-modules": "catalog:",
     "@types/file-saver": "catalog:",
     "@types/node": "catalog:",
+    "@types/qs": "catalog:",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
     "bumpp": "catalog:",
+    "qs": "catalog:",
     "tsdown": "catalog:",
-    "typescript": "catalog:",
-    "@tsdown/css": "catalog:"
+    "typescript": "catalog:"
   }
 }

--- a/src/frontend/packages/core/src/components/EntityTable/EntityTable.tsx
+++ b/src/frontend/packages/core/src/components/EntityTable/EntityTable.tsx
@@ -35,6 +35,7 @@ import { useDownloadOCEL, useDownloadResource } from "../../hooks/useDownload";
 import useInvalidate from "../../hooks/useInvalidate";
 import dayjs, { formatDateTime } from "../../lib/dayjs";
 import UploadSection from "../UploadSection/UploadSection";
+import { XESExportWindow } from "./XESExportWindow";
 
 type Entity = {
   type: "ocel" | "resource";
@@ -59,6 +60,10 @@ const EntityTable: React.FC = () => {
   });
 
   const invalidate = useInvalidate();
+
+  const [exportOcelId, setExportOcelId] = useState<string | undefined>(
+    undefined,
+  );
 
   const { download: downloadOCEL } = useDownloadOCEL();
   const { download: downloadResource } = useDownloadResource();
@@ -153,6 +158,11 @@ const EntityTable: React.FC = () => {
           onClose={() => setViewedResource(undefined)}
         />
       )}
+      <XESExportWindow
+        key={exportOcelId}
+        ocelId={exportOcelId}
+        onClose={() => setExportOcelId(undefined)}
+      />
       {entities.length ? (
         <DataTable<Entity>
           withTableBorder
@@ -276,6 +286,12 @@ const EntityTable: React.FC = () => {
                                 {extension}
                               </Menu.Item>
                             ))}
+                            <Menu.Item
+                              key={".xes"}
+                              onClick={() => setExportOcelId(id)}
+                            >
+                              {".xes"}
+                            </Menu.Item>
                           </Menu.Sub.Dropdown>
                         </Menu.Sub>
                       ) : (

--- a/src/frontend/packages/core/src/components/EntityTable/EntityTable.tsx
+++ b/src/frontend/packages/core/src/components/EntityTable/EntityTable.tsx
@@ -31,7 +31,7 @@ import {
 } from "lucide-react";
 import { DataTable } from "mantine-datatable";
 import { useCallback, useMemo, useState } from "react";
-import { useDownloadFile } from "../../hooks/useDownload";
+import { useDownloadOCEL, useDownloadResource } from "../../hooks/useDownload";
 import useInvalidate from "../../hooks/useInvalidate";
 import dayjs, { formatDateTime } from "../../lib/dayjs";
 import UploadSection from "../UploadSection/UploadSection";
@@ -59,7 +59,10 @@ const EntityTable: React.FC = () => {
   });
 
   const invalidate = useInvalidate();
-  const downloadFile = useDownloadFile();
+
+  const { download: downloadOCEL } = useDownloadOCEL();
+  const { download: downloadResource } = useDownloadResource();
+
   const { data: resourceMeta = {} } = useGetResourceMeta();
 
   const { mutate: deleteResource } = useDeleteResource({
@@ -267,9 +270,7 @@ const EntityTable: React.FC = () => {
                               <Menu.Item
                                 key={extension}
                                 onClick={() =>
-                                  downloadFile(
-                                    `/ocels/${id}/download?${new URLSearchParams({ ocel_id: id, ext: extension }).toString()}`,
-                                  )
+                                  downloadOCEL(id, { ext: extension })
                                 }
                               >
                                 {extension}
@@ -279,9 +280,7 @@ const EntityTable: React.FC = () => {
                         </Menu.Sub>
                       ) : (
                         <Menu.Item
-                          onClick={() =>
-                            downloadFile(`/resources/resource/${id}/download`)
-                          }
+                          onClick={() => downloadResource(id)}
                           leftSection={<DownloadIcon size={16} />}
                         >
                           Download

--- a/src/frontend/packages/core/src/components/EntityTable/XESExportWindow.tsx
+++ b/src/frontend/packages/core/src/components/EntityTable/XESExportWindow.tsx
@@ -1,0 +1,46 @@
+import { Button, Modal, Select, Stack } from "@mantine/core";
+import { useObjectCounts } from "@ocelescope/api-base";
+import { useState } from "react";
+import { useDownloadFlatOCEL } from "../../hooks/useDownload";
+
+export const XESExportWindow: React.FC<{
+  ocelId?: string;
+  onClose: () => void;
+}> = ({ ocelId, onClose }) => {
+  const { data: objectCounts } = useObjectCounts(ocelId ?? "", undefined, {
+    query: { enabled: !!ocelId },
+  });
+
+  const [selectedObjectType, setSelectedObjectType] = useState<string | null>(
+    null,
+  );
+
+  const { download } = useDownloadFlatOCEL();
+
+  return (
+    <Modal opened={!!ocelId} centered onClose={onClose} title="XES Export">
+      <Stack>
+        <Select
+          required
+          label="Select the object type to flatten the log to"
+          placeholder="Pick value"
+          data={Object.keys(objectCounts ?? {})}
+          searchable
+          value={selectedObjectType}
+          onChange={(newObjectType) => setSelectedObjectType(newObjectType)}
+        />
+        <Button
+          disabled={!selectedObjectType}
+          onClick={() => {
+            if (ocelId && selectedObjectType) {
+              download(ocelId, { object_type_name: selectedObjectType });
+              onClose();
+            }
+          }}
+        >
+          Export
+        </Button>
+      </Stack>
+    </Modal>
+  );
+};

--- a/src/frontend/packages/core/src/hooks/useDownload.ts
+++ b/src/frontend/packages/core/src/hooks/useDownload.ts
@@ -1,13 +1,19 @@
+import {
+  getDownloadFlatLogQueryKey,
+  getDownloadOCELQueryKey,
+  getDownloadResourceQueryKey,
+} from "@ocelescope/api-base";
 import { env, useSessionStore } from "@ocelescope/api-client";
 import { parse } from "content-disposition-attachment";
 import { saveAs } from "file-saver";
+import qs from "qs";
 
 export const useDownloadFile = () => {
   const { sessionId } = useSessionStore();
 
   const downloadFile = async (path: string) => {
     try {
-      const response = await fetch(`${env.backend_url}${path}`, {
+      const response = await fetch(path, {
         method: "GET",
         headers: { [env.session_id]: sessionId ?? "" },
       });
@@ -34,3 +40,34 @@ export const useDownloadFile = () => {
 
   return downloadFile;
 };
+
+const useDownloadFromServer =
+  <T extends (...args: any[]) => readonly [string, ...any[]]>(getQueryKey: T) =>
+  () => {
+    const downloadFile = useDownloadFile();
+
+    return {
+      download: (...params: Parameters<T>) => {
+        const result = getQueryKey(...params);
+        const path = result[0];
+        const searchParams = result[1];
+
+        const queryString = qs.stringify(searchParams, {
+          skipNulls: true,
+          indices: false,
+        });
+
+        downloadFile(queryString ? `${path}?${queryString}` : path);
+      },
+    };
+  };
+
+export const useDownloadOCEL = useDownloadFromServer(getDownloadOCELQueryKey);
+
+export const useDownloadFlatOCEL = useDownloadFromServer(
+  getDownloadFlatLogQueryKey,
+);
+
+export const useDownloadResource = useDownloadFromServer(
+  getDownloadResourceQueryKey,
+);

--- a/src/frontend/packages/core/tsconfig.json
+++ b/src/frontend/packages/core/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "@tsconfig/strictest/tsconfig.json",
   "compilerOptions": {
     "noPropertyAccessFromIndexSignature": false,
+    "exactOptionalPropertyTypes": false,
     "target": "esnext",
     "jsx": "react-jsx",
     "lib": ["es2023", "DOM"],


### PR DESCRIPTION
- part of #26 

This pr adds the export of object-centric event logs in the xes format

## Additional:
- Typed download hooks for resources, ocels  and flattend ocels 